### PR TITLE
Fixed possible typos in nonterminals

### DIFF
--- a/EEGPSRCmdGen/Resources/eegpsr_cat2e.txt
+++ b/EEGPSRCmdGen/Resources/eegpsr_cat2e.txt
@@ -10,7 +10,7 @@ $Main      = $task | ($polite $task)
 #
 ##############################################################################
 ; Greet person matching description
-$tgreet    = $greet the $person in the $roomE
+$task      = $greet the $person in the $roomE
 
 ; Count people
 $task  	   = tell me how many $people there are in the $roomE
@@ -56,18 +56,18 @@ $describeE = describe me the person $posture at the $beaconE
 ; Hard to find a person, easy to follow/guide
 $followE   = $vbfollow the $fgwhor ($fgrefuse | $fgabort)
 $followE   = $vbfollow the $fgwhorE
-$guideE    = $vbguide the $fgwhor $dest ($fgrefuse | $fgabort)
-$guideE    = $vbguide the $fgwhorE $dest
-$guideE    = $vbguide the $fgwhorE $destE
+$guideE    = $vbguide the $fgwhor $fgdest ($fgrefuse | $fgabort)
+$guideE    = $vbguide the $fgwhorE $fgdest
+$guideE    = $vbguide the $fgwhorE $fgdestE
 
 ; Easy-to-find person, but hard to follow/guide
 $followE   = $vbfollow the $fgwho $fgrefuse
-$followE   = $vbfollow the $fgwho $fbriefing $abort
+$followE   = $vbfollow the $fgwho $fbriefing $fgabort
 $followE   = $vbfollow the $fgwhoE $fbriefing
-$guideE    = $vbguide the $fgwho $dest $fgrefuse
-$guideE    = $vbguide the $fgwho $dest $gbriefing $abort
-$guideE    = $vbguide the $fgwhoE $dest $gbriefing
-$guideE    = $vbguide the $fgwho $destE $gbriefing
+$guideE    = $vbguide the $fgwho $fgdest $fgrefuse
+$guideE    = $vbguide the $fgwho $fgdest $gbriefing $fgabort
+$guideE    = $vbguide the $fgwhoE $fgdest $gbriefing
+$guideE    = $vbguide the $fgwho $fgdestE $gbriefing
 
 ; Helpers
 $fgwho     = person at the {beacon 1}

--- a/EEGPSRCmdGen/Resources/eegpsr_cat3i.txt
+++ b/EEGPSRCmdGen/Resources/eegpsr_cat3i.txt
@@ -28,7 +28,7 @@ $task      = $closedoorI
 $task      = $serveI
 
 ; Bring from description
-$task      = $bringdesc
+$task      = $bringdescI
 
 ; Count
 $task      = $countobjI
@@ -96,7 +96,7 @@ $ontrayI   = $vbdeliver me some $foodI and a $drinkI on a tray
 ##############################################################################
 $retrieveI = $vbdeliver me some {category} $storageI
 $storeI    = put the {object?} into the $storage
-$store     = pick up a {category meta: the object is on the {placement}} and put it into the $storage
+$storeI    = pick up a {category meta: the object is on the {placement}} and put it into the $storage
 
 
 
@@ -164,7 +164,7 @@ $foodI     = food {void meta: You want {object where Category="snack"} and a {ob
 $drinkI    = drink {void meta: You want {object where Category="drinks"} as drink}
 $storageI  = {void meta: object is in the (microwave | fridge | oven | ({object special where canPlaceIn=true} on the {placement}))}
 $canpourinI= container {void meta: Container is a {object where canPourIn=true}}
-$pourableI = something {void meta: You want some {object where canPour=true}}
+$pourableI = thing {void meta: You want some {object where canPour=true}}
 
 
 ##############################################################################


### PR DESCRIPTION
Hello,
I think I found some typos in the nonterminal names.
Changes needed for eegpsr_cat2e were quite obvious, while those for eegpsr_cat3i were tricky, and I couldn't tell which ways are your preferred(intended) ones.
Below are the changes(or what I tried to) + reasons:
#### eegpsr - cat2e
- `$tgreet` should be `$task`. (`$tgreet` is never used)
- `$dest`, `$destE` should be `$fgdest`, `$fgdestE`, respectively. (no rules for `$dest`, `$destE`)
- `$abort` should be `$fgabort`. (no rule for `$abort`)
#### eegpsr - cat3i
- `$task = $bringdesc` better be `$task = $bringdescI`.
In addition, meta information could be added to rules for `$bringdesc`, making them into `$bringdescI`. (e.g. `{category meta: There are three {category}s at the location}`)
- `$store = ...` better be `$storeI = ...`. (it actually lacks information)
- (English grammar) `$pourI` will be "... some something ...", when `$pourableI` is used.
I changed `$pourableI` to `thing`(was `something`), in order not to change the sentence itself.
It's going to be "some thing".